### PR TITLE
Add TYPO3 v14 support

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -12,7 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.2', '8.3', '8.4' ]
-        typo3: [ '12', '13' ]
+        typo3: [ '12', '13', '14' ]
+        exclude:
+          # TYPO3 v14 requires PHP >= 8.3
+          - php: '8.2'
+            typo3: '14'
     steps:
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
   "require": {
     "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
     "andersundsehr/sentry-async": "^3.0.0",
-    "networkteam/sentry-client": "^5.2.1",
-    "typo3/cms-core": "^12.4 || ^13.4"
+    "networkteam/sentry-client": "^5.2.1 || ^6.0",
+    "typo3/cms-core": "^12.4 || ^13.4 || ^14.0"
   },
   "require-dev": {
     "helhum/typo3-console": "^8.2",
@@ -21,7 +21,7 @@
     "typo3/cms-composer-installers": "^4.0-rc || ^5.0",
     "typo3/cms-lowlevel": "*",
     "typo3/cms-tstemplate": "*",
-    "typo3/minimal": "^13"
+    "typo3/minimal": "^13 || ^14"
   },
   "replace": {
     "pluswerk/sentry": "*"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "phpunit/phpunit": "^10 || ^12.3",
     "pluswerk/grumphp-config": "^7.2.0 || ^10.1.1",
     "pluswerk/sentry_test_extension": "@dev",
-    "saschaegerer/phpstan-typo3": "^1.10.2 || ^2.1.1",
+    "saschaegerer/phpstan-typo3": "^1.10.2 || ^2.1.1 || ^3.0",
     "ssch/typo3-rector": "^2.13.1 || ^3.6.2",
     "typo3/cms-composer-installers": "^4.0-rc || ^5.0",
     "typo3/cms-lowlevel": "*",


### PR DESCRIPTION
## What

Adds TYPO3 v14 compatibility.

- `composer.json`: allow `typo3/cms-core: ^14.0` and `networkteam/sentry-client: ^6.0` (v14 support landed there). The range `^5.2.1 || ^6.0` keeps TYPO3 v11–13 on sentry-client 5.x and v14 on 6.x, so **no supported TYPO3 version is dropped**. Dev-dep `typo3/minimal: ^13 || ^14`.
- CI: add `14` to the TYPO3 matrix (excluding PHP 8.2, which v14 dropped).

## Why it's a small change

The bridge's own code is already v14-signature-compatible:
- The wrapped `ContentObject\Exception\ProductionExceptionHandler::handle()` / `setConfiguration()` signatures are **unchanged** in v14, so the `#[Override]` wrapper in `ContentObjectProductionExceptionHandler` keeps compiling.
- `BreadcrumbLogger` (`AbstractWriter`/`WriterInterface`/`LogRecord`), the `Configuration/Services.php` DI (incl. the exception-handler service replacement) and the `ext_localconf.php` wiring all use APIs stable across v12–v14.

## Verification

Installed this branch into a real TYPO3 **v14.3** Composer project:
- `composer update` resolves cleanly → `networkteam/sentry-client 6.0.0` + `andersundsehr/sentry-async 3.1.0`.
- `typo3 cache:warmup` (DI container compile) succeeds — the `ProductionExceptionHandler` service replacement and the `BreadcrumbLogger` registration boot without error.
- `sentry_bridge` + `sentry_client` both report `active`.

I haven't ported the bundled functional test app (`config/`) to a v14 boot — happy to follow up if you'd like the matrix job green end-to-end before merge.